### PR TITLE
improve CLI error message & vignette

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ inst/doc
 /README.html
 **/figures/
 VennDiagram.*.log
+*_files/

--- a/R/cli.R
+++ b/R/cli.R
@@ -167,10 +167,10 @@ cli_from_json <- function(method, json, debug = FALSE) {
 
   # if needed, get moo from moo_input_rds
   accepted_args <- formals(method, envir = getNamespace("MOSuite"))
-  first_arg <- names(formals(method, envir = getNamespace("MOSuite")))[1]
+  first_arg <- names(accepted_args)[1]
   if (stringr::str_detect(first_arg, "^moo")) {
     assertthat::assert_that("moo_input_rds" %in% names(json_args),
-      msg = glue::glue("moo_input_rds must be included in the JSON because `moo` is required for {method}()")
+      msg = glue::glue("moo_input_rds must be included in the JSON because `{first_arg}` is required for {method}()")
     )
     fcn_args[[first_arg]] <- readr::read_rds(json_args[["moo_input_rds"]])
   }

--- a/vignettes/cli.Rmd
+++ b/vignettes/cli.Rmd
@@ -15,6 +15,14 @@ knitr::opts_chunk$set(
 )
 ```
 
+
+> ⚠️ **Most users do not need to use the CLI.**
+> We recommend using MOSuite within R scripts, R Markdown, or Quarto documents
+> for the vast majority of use-cases, as shown in the
+> [**introductory vignette**](https://ccbr.github.io/MOSuite/articles/intro.html).
+> The CLI is provided for a very specialized situation where MOSuite is run in
+> an environment that cannot use R scripts natively.
+
 MOSuite includes an executable file called `mosuite`.
 Any user-facing function in the MOSuite R package can be called with
 `mosuite [function]` from the unix CLI.
@@ -25,10 +33,12 @@ the JSON file can contain the following keys:
   - `moo_input_rds` - file path to an existing MultiOmicsDataset object in RDS format. This is required if the MOSuite function has `moo` as an argument (most user-facing functions do).
   - `moo_output_rds` - file path to write the result to.
 
-Run `mosuite --help` to see the full CLI usage:
+## Usage
+
+Run `mosuite --help` in a unix shell to see the full CLI usage:
 
 ```{r help, echo=FALSE, results='asis'}
-cat("```")
+cat("```sh")
 MOSuite:::cli_usage(con = stdout())
 cat("```")
 ```


### PR DESCRIPTION
## Changes

- mention the exact name of the function's first arg when throwing error that `moo_input_rds` is missing
- add a callout box to discourage most users from using the CLI in the vignette

## Issues

<!--
Reference any issues related to this PR.
If this PR fixes any issues,
[use a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
when referring to the issue so it will be closed automatically when the PR is merged.
-->

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [ ] Write unit tests for any new features, bug fixes, or other code changes.
- [x] Update the docs if there are any API changes (roxygen2 comments, vignettes, readme, etc.).
- ~[ ] Update `NEWS.md` with a short description of any user-facing changes and reference the PR number. Follow the style described in <https://style.tidyverse.org/news.html>~
- [ ] Run `devtools::check()` locally and fix all notes, warnings, and errors.
