### PR TITLE
fix: bug in batch_correct_counts()

### DIFF
--- a/R/batch-correction.R
+++ b/R/batch-correction.R
@@ -84,7 +84,7 @@ batch_correct_counts <- function(
   }
   # sva::ComBat() can't handle tibbles
   counts_dat <- counts_dat %>% as.data.frame()
-  sample_metadata <- moo@sample_meta
+  sample_metadata <- moo@sample_meta %>% as.data.frame()
   batch_vctr <- sample_metadata %>% dplyr::pull(batch_colname)
   message(
     glue::glue(


### PR DESCRIPTION
## Changes

sample_metadata was not converted to a dataframe, causing a failure when it is a tibble due to some outdated code that hasn't been updated yet.

I thought I fixed this in https://github.com/CCBR/MOSuite/pull/149 but they may have accidentally been overwritten when resolving merge conflicts.

## Issues

<!--
Reference any issues related to this PR.
If this PR fixes any issues,
[use a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
when referring to the issue so it will be closed automatically when the PR is merged.
-->

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [ ] This comment contains a description of changes with justifications, with any relevant issues linked.
- [ ] Write unit tests for any new features, bug fixes, or other code changes.
- [ ] Update the docs if there are any API changes (roxygen2 comments, vignettes, readme, etc.).
- [ ] Update `NEWS.md` with a short description of any user-facing changes and reference the PR number. Follow the style described in <https://style.tidyverse.org/news.html>
- [ ] Run `devtools::check()` locally and fix all notes, warnings, and errors.
