### PR TITLE
ci(auto-format): commit w/ CCBR-bot to trigger build workflow

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -3,10 +3,7 @@ name: auto-format
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main, master]
-
-env:
-  GH_TOKEN: ${{ github.token }}
+    branches: [ main, master ]
 
 permissions:
   contents: write
@@ -21,15 +18,25 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.CCBR_BOT_APP_ID }}
+          private-key: ${{ secrets.CCBR_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - uses: actions/checkout@v6
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0
-          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref ||
+            github.ref_name }}
 
       - name: git config
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "CCBR-bot"
+          git config --global user.email "258092125+ccbr-bot@users.noreply.github.com"
 
       - uses: CCBR/actions/install-r-pak@main
         with:


### PR DESCRIPTION
## Changes

allows R-CMD-check to run after the auto-format workflow pushes changes

## Issues

<!--
Reference any issues related to this PR.
If this PR fixes any issues,
[use a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
when referring to the issue so it will be closed automatically when the PR is merged.
-->

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- ~[ ] This comment contains a description of changes with justifications, with any relevant issues linked.~
- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~
- ~[ ] Update the docs if there are any API changes (roxygen2 comments, vignettes, readme, etc.).~
- ~[ ] Update `NEWS.md` with a short description of any user-facing changes and reference the PR number. Follow the style described in <https://style.tidyverse.org/news.html>~
- [x] Run `devtools::check()` locally and fix all notes, warnings, and errors.
