### PR TITLE
chore: add script to run check via podman

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -50,20 +50,29 @@ cd MOSuite
 
 ### If this is your first time cloning the repo, install dependencies
 
+#### R dependencies
+
 - In an R console, install the R development dependencies with
-  `devtools::install_dev_deps()`, and then make sure the package passes R CMD
-  check by running `devtools::check()`. If R CMD check doesn't pass cleanly,
-  it's a good idea to ask for help before continuing.
+  `devtools::install_dev_deps()`.
+- Alternatively, we have a docker container available with MOSuite's dependencies installed:
+  [`docker://nciccbr/mosuite-minmal:latest`](https://hub.docker.com/r/nciccbr/mosuite-minimal).
+  You can launch the container using your preferred engine (e.g. Docker, Podman, apptainer/singularity)
+  with your clone of the repo mounted while developing your contributions.
 
-- Install [`pre-commit`](https://pre-commit.com/#install) if you don't already
-  have it. Then from the repo's root directory, run
+Before you make any changes, make sure the package passes R CMD check by running `devtools::check()`.
+If R CMD check doesn't pass cleanly, it's a good idea to **ask for help before continuing**.
 
-  ```sh
-  pre-commit install
-  ```
+#### Pre-commit
 
-  This will install the repo's pre-commit hooks.
-  You'll only need to do this step the first time you clone the repo.
+Install [`pre-commit`](https://pre-commit.com/#install) if you don't already
+have it. Then from the repo's root directory, run
+
+```sh
+pre-commit install
+```
+
+This will install the repo's pre-commit hooks.
+You'll only need to do this step the first time you clone the repo.
 
 ### Create a branch
 

--- a/inst/extdata/run-check-podman.sh
+++ b/inst/extdata/run-check-podman.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Run `devtools::check()` locally inside the mosuite-minimal container image
+# via podman (e.g. on macOS with Podman Desktop / podman machine).
+# Note: you may need to disable the VPN in order to pull the image.
+#
+# Usage:
+#   ./inst/extdata/run-check-podman.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+IMAGE="docker.io/nciccbr/mosuite-minimal:latest"
+
+if ! command -v podman >/dev/null 2>&1; then
+  echo "Error: podman is not installed or not on \$PATH. Install it from https://podman.io/" >&2
+  exit 1
+fi
+
+if ! podman info >/dev/null 2>&1; then
+  echo "Podman machine is not running. Starting it..." >&2
+  podman machine set --memory 8192 && podman machine start
+fi
+
+echo "Using image: $IMAGE"
+podman pull "$IMAGE"
+
+podman run --rm \
+  -v "$REPO_ROOT":/workspace:Z \
+  -w /workspace \
+  "$IMAGE" \
+  R -e 'devtools::check()'


### PR DESCRIPTION
## Changes

adds a script for developers to use to run devtools::check() inside the minimal container via podman -- intended for macOS

## Issues

NA

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~
- ~[ ] Update the docs if there are any API changes (roxygen2 comments, vignettes, readme, etc.).~
- ~[ ] Update `NEWS.md` with a short description of any user-facing changes and reference the PR number. Follow the style described in <https://style.tidyverse.org/news.html>~
- [ ] Run `devtools::check()` locally and fix all notes, warnings, and errors.
