### PR TITLE
fix: align volcano threshold behavior

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -605,7 +605,7 @@ references:
   doi: 10.32614/CRAN.package.broom
 - type: software
   title: cffr
-  abstract: 'cffr: Generate Citation File Format (''CFF'') Metadata for R Packages'
+  abstract: 'cffr: Generate Citation File Format (''CFF'') Metadata'
   notes: Suggests
   url: https://docs.ropensci.org/cffr/
   repository: https://CRAN.R-project.org/package=cffr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 ## MOSuite development version
 
+- Align Volcano Plot threshold comparisons across labeling, coloring, and summary filtering, and use resolved column names for classification. (#266, @TJoshMeyer)
+
 ## MOSuite 0.4.1
 
 - Fix how `plot_volcano_summary()` & `plot_volcano_enhanced` handle detecting column names for features, significance, and fold-change. `plot_volcano_summary()` plot now uses `plot_volcano_enhanced()` for rendering. (#239, @phoman14)

--- a/R/differential.R
+++ b/R/differential.R
@@ -568,11 +568,11 @@ plot_mean_variance <- function(voom_elist) {
 #' @inheritParams option_params
 #' @inheritParams filter_counts
 #' @param significance_column Column name for significance, e.g. `"pval"` or `"pvaladj"` (default)
-#' @param significance_cutoff Features will only be kept if their `significance_column` is less then this cutoff
-#'   threshold
+#' @param significance_cutoff Features will only be kept if their `significance_column` is less than the cutoff
+#'   threshold (exclusive)
 #' @param change_column Column name for change, e.g. `"logFC"` (default)
-#' @param change_cutoff Features will only be kept if the absolute value of their `change_column` is greater than or
-#'   equal to this cutoff threshold
+#' @param change_cutoff Features will only be kept if the absolute value of their `change_column` is greater than the
+#'   cutoff threshold (exclusive)
 #' @param filtering_mode Accepted values: `"any"` or `"all"` to include features that meet the criteria in _any_
 #'   contrast or in _all_ contrasts
 #' @param include_estimates Column names of estimates to include. Default: `c("FC", "logFC", "tstat", "pval",

--- a/R/differential.R
+++ b/R/differential.R
@@ -744,7 +744,7 @@ filter_diff <- function(
 
   ## filter genes
   significant <- datsignif < significance_cutoff
-  changed <- abs(datchange) >= change_cutoff
+  changed <- abs(datchange) > change_cutoff
   if (filtering_mode == "any") {
     selgenes <- apply(significant & changed, 1, any)
     select_genes <- genes[selgenes]
@@ -763,7 +763,7 @@ filter_diff <- function(
   message(
     glue::glue(
       "Total number of genes selected with {significance_column} < {significance_cutoff}",
-      " and \u007c {change_column} \u007c \u2265 {change_cutoff} is sum(selgenes)"
+      " and \u007c {change_column} \u007c > {change_cutoff} is sum(selgenes)"
     )
   )
 
@@ -777,8 +777,8 @@ filter_diff <- function(
 
   ### PH: START Create DEG summary Barplot
   ## do plot
-  significant <- apply(datsignif, 2, function(x) x <= significance_cutoff)
-  changed <- apply(datchange, 2, function(x) abs(x) >= change_cutoff)
+  significant <- apply(datsignif, 2, function(x) x < significance_cutoff)
+  changed <- apply(datchange, 2, function(x) abs(x) > change_cutoff)
   dd <- significant & changed
   if (draw_bar_border) {
     bar_border <- "black"

--- a/R/plot_volcano_enhanced.R
+++ b/R/plot_volcano_enhanced.R
@@ -168,9 +168,10 @@ S7::method(plot_volcano_enhanced, multiOmicDataSet) <- function(
 #'   contrast (e.g. `c("B-A_adjpval", "C-A_adjpval")`). Defaults to `NULL`,
 #'   which auto-detects corresponding columns by checking for `_adjpval` first,
 #'   then `_pval`, for each contrast in `change_colname`.
-#' @param signif_threshold Numeric significance threshold (p-value or adjusted p-value cutoff). Default: 0.05
+#' @param signif_threshold Numeric significance threshold (p-value or adjusted p-value cutoff). Features meet this
+#'   threshold when their value is less than the cutoff. Default: 0.05
 #' @param change_threshold Numeric value specifying the fold change cutoff for significance (i.e. filters on
-#'   `change_colname`)
+#'   `change_colname`). Features meet this threshold when the absolute value is greater than the cutoff.
 #' @param value_to_sort_the_output_dataset How to sort the output dataset. Options are "fold-change", "p-value", or
 #'   "t-statistic".
 #' @param num_features_to_label Number of top features/genes to label in the volcano plot. Default is 30.
@@ -390,11 +391,23 @@ S7::method(plot_volcano_enhanced, S7::class_data.frame) <- function(
 
     significant <- vector(length = nrow(df))
     significant[] <- "Not significant"
-    significant[which(abs(df[, 2]) > change_threshold)] <- "Fold change only"
-    significant[which(df[, 3] < signif_threshold)] <- "Significant only"
-    significant[which(
-      abs(df[, 2]) > change_threshold & df[, 3] < signif_threshold
-    )] <- "Significant and fold change"
+    meets_change <- !is.na(df[[lfc_name]]) &
+      abs(df[[lfc_name]]) > change_threshold
+    meets_significance <- !is.na(df[[sig_name]]) &
+      df[[sig_name]] < signif_threshold
+    significant[meets_change] <- "Fold change only"
+    significant[meets_significance] <- "Significant only"
+    significant[meets_change & meets_significance] <-
+      "Significant and fold change"
+    color_values <- c(
+      "Not significant" = color_of_non_significant_features,
+      "Fold change only" = color_of_logfold_change_threshold_line,
+      "Significant only" = color_of_features_meeting_only_signif_threshold,
+      "Significant and fold change" =
+        color_for_features_meeting_pvalue_and_foldchange_thresholds
+    )
+    custom_colors <- unname(color_values[significant])
+    names(custom_colors) <- significant
 
     ### PH: END Build table for Volcano plot
 
@@ -525,6 +538,7 @@ S7::method(plot_volcano_enhanced, S7::class_data.frame) <- function(
         color_of_features_meeting_only_signif_threshold,
         color_for_features_meeting_pvalue_and_foldchange_thresholds
       ),
+      colCustom = custom_colors,
       cutoffLineCol = color_of_signif_threshold_line,
       shapeCustom = shapeCustom
     ) +
@@ -563,6 +577,7 @@ S7::method(plot_volcano_enhanced, S7::class_data.frame) <- function(
           color_of_features_meeting_only_signif_threshold,
           color_for_features_meeting_pvalue_and_foldchange_thresholds
         ),
+        colCustom = custom_colors,
         cutoffLineCol = color_of_signif_threshold_line,
         shapeCustom = shapeCustom
       ) +

--- a/R/plot_volcano_enhanced.R
+++ b/R/plot_volcano_enhanced.R
@@ -403,8 +403,7 @@ S7::method(plot_volcano_enhanced, S7::class_data.frame) <- function(
       "Not significant" = color_of_non_significant_features,
       "Fold change only" = color_of_logfold_change_threshold_line,
       "Significant only" = color_of_features_meeting_only_signif_threshold,
-      "Significant and fold change" =
-        color_for_features_meeting_pvalue_and_foldchange_thresholds
+      "Significant and fold change" = color_for_features_meeting_pvalue_and_foldchange_thresholds
     )
     custom_colors <- unname(color_values[significant])
     names(custom_colors) <- significant

--- a/R/plot_volcano_enhanced.R
+++ b/R/plot_volcano_enhanced.R
@@ -107,6 +107,8 @@ S7::method(plot_volcano_enhanced, multiOmicDataSet) <- function(
   plots_subdir = "diff",
   plot_filename = "volcano_enhanced.png"
 ) {
+  sig_fc_color <- color_for_features_meeting_pvalue_and_foldchange_thresholds
+
   return(
     join_dfs_wide(moo_diff@analyses$diff) |>
       plot_volcano_enhanced(
@@ -140,7 +142,7 @@ S7::method(plot_volcano_enhanced, multiOmicDataSet) <- function(
         color_of_non_significant_features = color_of_non_significant_features,
         color_of_logfold_change_threshold_line = color_of_logfold_change_threshold_line,
         color_of_features_meeting_only_signif_threshold = color_of_features_meeting_only_signif_threshold,
-        color_for_features_meeting_pvalue_and_foldchange_thresholds = color_for_features_meeting_pvalue_and_foldchange_thresholds,
+        color_for_features_meeting_pvalue_and_foldchange_thresholds = sig_fc_color,
         graphics_device = graphics_device,
         image_width = image_width,
         image_height = image_height,
@@ -355,14 +357,18 @@ S7::method(plot_volcano_enhanced, S7::class_data.frame) <- function(
 
     if (label_significant_features_only) {
       df_sub <- df[
-        df[[sig_name]] <= signif_threshold &
-          abs(df[[lfc_name]]) >= change_threshold,
+        df[[sig_name]] < signif_threshold &
+          abs(df[[lfc_name]]) > change_threshold,
       ]
     } else {
       df_sub <- df
     }
 
-    genes_to_label <- as.character(df_sub[1:num_features_to_label, label_col])
+    if (nrow(df_sub) == 0) {
+      genes_to_label <- character(0)
+    } else {
+      genes_to_label <- as.character(df_sub[1:num_features_to_label, label_col])
+    }
     split_values <- unlist(strsplit(gsub(",", " ", custom_gene_list), " "))
     custom_labels <- split_values[split_values != ""]
 

--- a/R/plot_volcano_enhanced.R
+++ b/R/plot_volcano_enhanced.R
@@ -107,6 +107,7 @@ S7::method(plot_volcano_enhanced, multiOmicDataSet) <- function(
   plots_subdir = "diff",
   plot_filename = "volcano_enhanced.png"
 ) {
+  # Local alias for long parameter name to satisfy 120-character line length linter
   sig_fc_color <- color_for_features_meeting_pvalue_and_foldchange_thresholds
 
   return(
@@ -171,9 +172,10 @@ S7::method(plot_volcano_enhanced, multiOmicDataSet) <- function(
 #'   which auto-detects corresponding columns by checking for `_adjpval` first,
 #'   then `_pval`, for each contrast in `change_colname`.
 #' @param signif_threshold Numeric significance threshold (p-value or adjusted p-value cutoff). Features meet this
-#'   threshold when their value is less than the cutoff. Default: 0.05
+#'   threshold when their value is less than the cutoff (exclusive). Default: 0.05
 #' @param change_threshold Numeric value specifying the fold change cutoff for significance (i.e. filters on
-#'   `change_colname`). Features meet this threshold when the absolute value is greater than the cutoff.
+#'   `change_colname`). Features meet this threshold when the absolute value is greater than the cutoff (exclusive).
+#'   Default: 1.0
 #' @param value_to_sort_the_output_dataset How to sort the output dataset. Options are "fold-change", "p-value", or
 #'   "t-statistic".
 #' @param num_features_to_label Number of top features/genes to label in the volcano plot. Default is 30.

--- a/R/plot_volcano_summary.R
+++ b/R/plot_volcano_summary.R
@@ -175,7 +175,7 @@ S7::method(plot_volcano_summary, multiOmicDataSet) <- function(
 #'   which auto-detects corresponding columns by checking for `_adjpval` first,
 #'   then `_pval`, for each contrast in `change_colname`.
 #' @param signif_threshold Numeric significance threshold (p-value or adjusted p-value cutoff). Features meet this
-#'   threshold when their value is less than the cutoff. Default: 0.05
+#'   threshold when their value is less than the cutoff (exclusive). Default: 0.05
 #' @param add_features Add custom_gene_list To Labels. Set TRUE when you want to label a specific set of features
 #'   (features) in the "custom_gene_list" parameter" IN ADDITION to the number of features you set in the "Number of
 #'   Features to Label" parameter.
@@ -275,6 +275,7 @@ S7::method(plot_volcano_summary, S7::class_data.frame) <- function(
   plots_subdir = "diff"
 ) {
   abort_packages_not_installed("EnhancedVolcano")
+  sig_fc_color <- color_for_features_meeting_pvalue_and_foldchange_thresholds
   diff_dat <- as.data.frame(moo_diff)
 
   ## -------------------------------- ##
@@ -434,7 +435,7 @@ S7::method(plot_volcano_summary, S7::class_data.frame) <- function(
     color_of_non_significant_features = color_of_non_significant_features,
     color_of_logfold_change_threshold_line = color_of_logfold_change_threshold_line,
     color_of_features_meeting_only_signif_threshold = color_of_features_meeting_only_signif_threshold,
-    color_for_features_meeting_pvalue_and_foldchange_thresholds = color_for_features_meeting_pvalue_and_foldchange_thresholds,
+    color_for_features_meeting_pvalue_and_foldchange_thresholds = sig_fc_color,
     graphics_device = graphics_device,
     image_width = image_width * dpi,
     image_height = image_height * dpi,

--- a/R/plot_volcano_summary.R
+++ b/R/plot_volcano_summary.R
@@ -174,7 +174,8 @@ S7::method(plot_volcano_summary, multiOmicDataSet) <- function(
 #'   per contrast (e.g. `c("B-A_adjpval", "C-A_adjpval")`). Defaults to `NULL`,
 #'   which auto-detects corresponding columns by checking for `_adjpval` first,
 #'   then `_pval`, for each contrast in `change_colname`.
-#' @param signif_threshold Numeric significance threshold (p-value or adjusted p-value cutoff). Default: 0.05
+#' @param signif_threshold Numeric significance threshold (p-value or adjusted p-value cutoff). Features meet this
+#'   threshold when their value is less than the cutoff. Default: 0.05
 #' @param add_features Add custom_gene_list To Labels. Set TRUE when you want to label a specific set of features
 #'   (features) in the "custom_gene_list" parameter" IN ADDITION to the number of features you set in the "Number of
 #'   Features to Label" parameter.
@@ -360,8 +361,8 @@ S7::method(plot_volcano_summary, S7::class_data.frame) <- function(
     plot_signif_colnames <- c(plot_signif_colnames, pvalcol)
 
     filtered_features <- feature_ids[
-      diff_dat[, pvalcol] < signif_threshold &
-        abs(diff_dat[, new_contrast_label]) > change_threshold
+      diff_dat[[pvalcol]] < signif_threshold &
+        abs(diff_dat[[new_contrast_label]]) > change_threshold
     ]
     repeated_column <- rep(contrast, length(filtered_features))
 

--- a/man/filter_diff.Rd
+++ b/man/filter_diff.Rd
@@ -43,13 +43,13 @@ used.)}
 
 \item{significance_column}{Column name for significance, e.g. \code{"pval"} or \code{"pvaladj"} (default)}
 
-\item{significance_cutoff}{Features will only be kept if their \code{significance_column} is less then this cutoff
-threshold}
+\item{significance_cutoff}{Features will only be kept if their \code{significance_column} is less than the cutoff
+threshold (exclusive)}
 
 \item{change_column}{Column name for change, e.g. \code{"logFC"} (default)}
 
-\item{change_cutoff}{Features will only be kept if the absolute value of their \code{change_column} is greater than or
-equal to this cutoff threshold}
+\item{change_cutoff}{Features will only be kept if the absolute value of their \code{change_column} is greater than the
+cutoff threshold (exclusive)}
 
 \item{filtering_mode}{Accepted values: \code{"any"} or \code{"all"} to include features that meet the criteria in \emph{any}
 contrast or in \emph{all} contrasts}

--- a/man/plot_volcano_enhanced.Rd
+++ b/man/plot_volcano_enhanced.Rd
@@ -167,10 +167,10 @@ which auto-detects corresponding columns by checking for \verb{_adjpval} first,
 then \verb{_pval}, for each contrast in \code{change_colname}.}
 
 \item{signif_threshold}{Numeric significance threshold (p-value or adjusted p-value cutoff). Features meet this
-threshold when their value is less than the cutoff. Default: 0.05}
+threshold when their value is less than the cutoff (exclusive). Default: 0.05}
 
 \item{change_threshold}{Numeric value specifying the fold change cutoff for significance (i.e. filters on
-\code{change_colname}). Features meet this threshold when the absolute value is greater than the cutoff.}
+\code{change_colname}). Features meet this threshold when the absolute value is greater than the cutoff (exclusive). Default: 1.0}
 
 \item{value_to_sort_the_output_dataset}{How to sort the output dataset. Options are "fold-change", "p-value", or
 "t-statistic".}

--- a/man/plot_volcano_enhanced.Rd
+++ b/man/plot_volcano_enhanced.Rd
@@ -170,7 +170,7 @@ then \verb{_pval}, for each contrast in \code{change_colname}.}
 threshold when their value is less than the cutoff. Default: 0.05}
 
 \item{change_threshold}{Numeric value specifying the fold change cutoff for significance (i.e. filters on
-\code{change_colname}). Features meet this threshold when the absolute value is greater than the cutoff. Default: 1.0}
+\code{change_colname}). Features meet this threshold when the absolute value is greater than the cutoff.}
 
 \item{value_to_sort_the_output_dataset}{How to sort the output dataset. Options are "fold-change", "p-value", or
 "t-statistic".}

--- a/man/plot_volcano_enhanced.Rd
+++ b/man/plot_volcano_enhanced.Rd
@@ -166,10 +166,11 @@ contrast (e.g. \code{c("B-A_adjpval", "C-A_adjpval")}). Defaults to \code{NULL},
 which auto-detects corresponding columns by checking for \verb{_adjpval} first,
 then \verb{_pval}, for each contrast in \code{change_colname}.}
 
-\item{signif_threshold}{Numeric significance threshold (p-value or adjusted p-value cutoff). Default: 0.05}
+\item{signif_threshold}{Numeric significance threshold (p-value or adjusted p-value cutoff). Features meet this
+threshold when their value is less than the cutoff. Default: 0.05}
 
 \item{change_threshold}{Numeric value specifying the fold change cutoff for significance (i.e. filters on
-\code{change_colname})}
+\code{change_colname}). Features meet this threshold when the absolute value is greater than the cutoff.}
 
 \item{value_to_sort_the_output_dataset}{How to sort the output dataset. Options are "fold-change", "p-value", or
 "t-statistic".}

--- a/man/plot_volcano_enhanced.Rd
+++ b/man/plot_volcano_enhanced.Rd
@@ -170,7 +170,8 @@ then \verb{_pval}, for each contrast in \code{change_colname}.}
 threshold when their value is less than the cutoff (exclusive). Default: 0.05}
 
 \item{change_threshold}{Numeric value specifying the fold change cutoff for significance (i.e. filters on
-\code{change_colname}). Features meet this threshold when the absolute value is greater than the cutoff (exclusive). Default: 1.0}
+\code{change_colname}). Features meet this threshold when the absolute value is greater than the cutoff (exclusive).
+Default: 1.0}
 
 \item{value_to_sort_the_output_dataset}{How to sort the output dataset. Options are "fold-change", "p-value", or
 "t-statistic".}

--- a/man/plot_volcano_enhanced.Rd
+++ b/man/plot_volcano_enhanced.Rd
@@ -170,7 +170,7 @@ then \verb{_pval}, for each contrast in \code{change_colname}.}
 threshold when their value is less than the cutoff. Default: 0.05}
 
 \item{change_threshold}{Numeric value specifying the fold change cutoff for significance (i.e. filters on
-\code{change_colname}). Features meet this threshold when the absolute value is greater than the cutoff.}
+\code{change_colname}). Features meet this threshold when the absolute value is greater than the cutoff. Default: 1.0}
 
 \item{value_to_sort_the_output_dataset}{How to sort the output dataset. Options are "fold-change", "p-value", or
 "t-statistic".}

--- a/man/plot_volcano_summary.Rd
+++ b/man/plot_volcano_summary.Rd
@@ -173,7 +173,8 @@ then \verb{_pval}, for each contrast in \code{change_colname}.}
 threshold when their value is less than the cutoff (exclusive). Default: 0.05}
 
 \item{change_threshold}{Numeric value specifying the fold change cutoff for significance (i.e. filters on
-\code{change_colname}). Features meet this threshold when the absolute value is greater than the cutoff (exclusive). Default: 1.0}
+\code{change_colname}). Features meet this threshold when the absolute value is greater than the cutoff (exclusive).
+Default: 1.0}
 
 \item{value_to_sort_the_output_dataset}{How to sort the output dataset. Options are "fold-change", "p-value", or
 "t-statistic".}

--- a/man/plot_volcano_summary.Rd
+++ b/man/plot_volcano_summary.Rd
@@ -170,10 +170,10 @@ which auto-detects corresponding columns by checking for \verb{_adjpval} first,
 then \verb{_pval}, for each contrast in \code{change_colname}.}
 
 \item{signif_threshold}{Numeric significance threshold (p-value or adjusted p-value cutoff). Features meet this
-threshold when their value is less than the cutoff. Default: 0.05}
+threshold when their value is less than the cutoff (exclusive). Default: 0.05}
 
 \item{change_threshold}{Numeric value specifying the fold change cutoff for significance (i.e. filters on
-\code{change_colname}). Features meet this threshold when the absolute value is greater than the cutoff.}
+\code{change_colname}). Features meet this threshold when the absolute value is greater than the cutoff (exclusive). Default: 1.0}
 
 \item{value_to_sort_the_output_dataset}{How to sort the output dataset. Options are "fold-change", "p-value", or
 "t-statistic".}

--- a/man/plot_volcano_summary.Rd
+++ b/man/plot_volcano_summary.Rd
@@ -173,7 +173,7 @@ then \verb{_pval}, for each contrast in \code{change_colname}.}
 threshold when their value is less than the cutoff. Default: 0.05}
 
 \item{change_threshold}{Numeric value specifying the fold change cutoff for significance (i.e. filters on
-\code{change_colname}). Features meet this threshold when the absolute value is greater than the cutoff. Default: 1.0}
+\code{change_colname}). Features meet this threshold when the absolute value is greater than the cutoff.}
 
 \item{value_to_sort_the_output_dataset}{How to sort the output dataset. Options are "fold-change", "p-value", or
 "t-statistic".}

--- a/man/plot_volcano_summary.Rd
+++ b/man/plot_volcano_summary.Rd
@@ -173,7 +173,7 @@ then \verb{_pval}, for each contrast in \code{change_colname}.}
 threshold when their value is less than the cutoff. Default: 0.05}
 
 \item{change_threshold}{Numeric value specifying the fold change cutoff for significance (i.e. filters on
-\code{change_colname}). Features meet this threshold when the absolute value is greater than the cutoff.}
+\code{change_colname}). Features meet this threshold when the absolute value is greater than the cutoff. Default: 1.0}
 
 \item{value_to_sort_the_output_dataset}{How to sort the output dataset. Options are "fold-change", "p-value", or
 "t-statistic".}

--- a/man/plot_volcano_summary.Rd
+++ b/man/plot_volcano_summary.Rd
@@ -169,10 +169,11 @@ per contrast (e.g. \code{c("B-A_adjpval", "C-A_adjpval")}). Defaults to \code{NU
 which auto-detects corresponding columns by checking for \verb{_adjpval} first,
 then \verb{_pval}, for each contrast in \code{change_colname}.}
 
-\item{signif_threshold}{Numeric significance threshold (p-value or adjusted p-value cutoff). Default: 0.05}
+\item{signif_threshold}{Numeric significance threshold (p-value or adjusted p-value cutoff). Features meet this
+threshold when their value is less than the cutoff. Default: 0.05}
 
 \item{change_threshold}{Numeric value specifying the fold change cutoff for significance (i.e. filters on
-\code{change_colname})}
+\code{change_colname}). Features meet this threshold when the absolute value is greater than the cutoff.}
 
 \item{value_to_sort_the_output_dataset}{How to sort the output dataset. Options are "fold-change", "p-value", or
 "t-statistic".}

--- a/tests/testthat/_snaps/E2E.md
+++ b/tests/testthat/_snaps/E2E.md
@@ -49,7 +49,7 @@
       Setting first column of `counts` as gene annotation.
       Total number of genes included: 291
       * filtering differential features
-      Total number of genes selected with adjpval < 0.05 and | logFC | ≥ 1 is sum(selgenes)
+      Total number of genes selected with adjpval < 0.05 and | logFC | > 1 is sum(selgenes)
 
 # E2E workflow succeeds for NIDAP data
 
@@ -100,5 +100,5 @@
       Joining with `by = join_by(GeneName)`
       Joining with `by = join_by(GeneName)`
       * filtering differential features
-      Total number of genes selected with adjpval < 0.05 and | logFC | ≥ 1 is sum(selgenes)
+      Total number of genes selected with adjpval < 0.05 and | logFC | > 1 is sum(selgenes)
 

--- a/tests/testthat/test-differential.R
+++ b/tests/testthat/test-differential.R
@@ -494,3 +494,36 @@ test_that("filter_diff accepts valid plot_type values", {
     moo |> filter_diff(plot_type = "pie")
   )
 })
+
+test_that("filter_diff excludes exact boundary values using strict comparisons", {
+  options(moo_print_plots = FALSE)
+  boundary_df <- data.frame(
+    Gene = c(
+      "both_boundary",
+      "p_boundary",
+      "fc_boundary",
+      "strict_hit",
+      "neither"
+    ),
+    `B-A_FC` = c(2, 1.414, 2, 2.3, 1.414),
+    `B-A_logFC` = c(1.0, 0.5, 1.0, 1.2, 0.5),
+    `B-A_tstat` = c(2.0, 1.0, 2.0, 2.5, 1.0),
+    `B-A_pval` = c(0.05, 0.05, 0.06, 0.04, 0.06),
+    `B-A_adjpval` = c(0.05, 0.05, 0.06, 0.04, 0.06),
+    check.names = FALSE
+  )
+  moo <- moo_nidap
+  moo@analyses$diff <- list("B-A" = boundary_df)
+  out <- filter_diff(
+    moo,
+    feature_id_colname = "Gene",
+    significance_column = "adjpval",
+    significance_cutoff = 0.05,
+    change_column = "logFC",
+    change_cutoff = 1.0,
+    filtering_mode = "any",
+    print_plots = FALSE,
+    save_plots = FALSE
+  )
+  expect_equal(out@analyses$diff_filt$Gene, "strict_hit")
+})

--- a/tests/testthat/test-plot_volcano_enhanced.R
+++ b/tests/testthat/test-plot_volcano_enhanced.R
@@ -84,6 +84,51 @@ test_that("plot_volcano_enhanced forwards shared styling parameters", {
   expect_equal(captured_args$cutoffLineCol, "cyan")
 })
 
+test_that("plot_volcano_enhanced colors exact threshold boundaries as non-significant", {
+  options(mosuite_test_volcano_boundary_args = list())
+  trace(
+    EnhancedVolcano::EnhancedVolcano,
+    tracer = quote(options(
+      mosuite_test_volcano_boundary_args = append(
+        getOption("mosuite_test_volcano_boundary_args"),
+        list(list(colCustom = colCustom))
+      )
+    )),
+    print = FALSE
+  )
+  on.exit(untrace(EnhancedVolcano::EnhancedVolcano), add = TRUE)
+  on.exit(options(mosuite_test_volcano_boundary_args = NULL), add = TRUE)
+
+  boundary_data <- data.frame(
+    Gene = c("both_boundary", "p_boundary", "fc_boundary", "neither"),
+    annotation = c("a", "b", "c", "d"),
+    `B-A_logFC` = c(1, 0.5, 1, 0.5),
+    `B-A_pval` = c(0.05, 0.05, 0.06, 0.06),
+    check.names = FALSE
+  )
+
+  plot_volcano_enhanced(
+    boundary_data,
+    feature_id_colname = "Gene",
+    change_colname = "B-A_logFC",
+    signif_colname = "B-A_pval",
+    save_plots = FALSE,
+    print_plots = FALSE
+  )
+
+  captured_colors <- getOption("mosuite_test_volcano_boundary_args")[[1]]$colCustom
+  expect_equal(
+    captured_colors[names(captured_colors) == "Not significant"],
+    rep("grey30", 2)
+  )
+  expect_true(
+    all(captured_colors[names(captured_colors) == "Significant only"] == "royalblue")
+  )
+  expect_true(
+    all(captured_colors[names(captured_colors) == "Fold change only"] == "forestgreen")
+  )
+})
+
 test_that("plot_volcano_enhanced uses EnhancedVolcano default colors", {
   options(mosuite_test_volcano_args = list())
   trace(

--- a/tests/testthat/test-plot_volcano_enhanced.R
+++ b/tests/testthat/test-plot_volcano_enhanced.R
@@ -86,6 +86,8 @@ test_that("plot_volcano_enhanced forwards shared styling parameters", {
 
 test_that("plot_volcano_enhanced colors exact threshold boundaries as non-significant", {
   options(mosuite_test_volcano_boundary_args = list())
+  # Dynamically intercept internal arguments (colCustom) passed into EnhancedVolcano
+  # to verify point-color assignments without modifying package source code.
   trace(
     EnhancedVolcano::EnhancedVolcano,
     tracer = quote(options(

--- a/tests/testthat/test-plot_volcano_enhanced.R
+++ b/tests/testthat/test-plot_volcano_enhanced.R
@@ -120,8 +120,8 @@ test_that("plot_volcano_enhanced colors exact threshold boundaries as non-signif
     1
   ]]$colCustom
   expect_equal(
-    captured_colors[names(captured_colors) == "Not significant"],
-    rep("grey30", 2)
+    unname(captured_colors[names(captured_colors) == "Not significant"]),
+    rep("grey30", 4)
   )
   expect_true(
     all(
@@ -135,6 +135,43 @@ test_that("plot_volcano_enhanced colors exact threshold boundaries as non-signif
         "forestgreen"
     )
   )
+})
+
+test_that("plot_volcano_enhanced labels only strict threshold hits", {
+  options(mosuite_test_volcano_label_args = list())
+  trace(
+    EnhancedVolcano::EnhancedVolcano,
+    tracer = quote(options(
+      mosuite_test_volcano_label_args = append(
+        getOption("mosuite_test_volcano_label_args"),
+        list(list(selectLab = selectLab))
+      )
+    )),
+    print = FALSE
+  )
+  on.exit(untrace(EnhancedVolcano::EnhancedVolcano), add = TRUE)
+  on.exit(options(mosuite_test_volcano_label_args = NULL), add = TRUE)
+
+  boundary_data <- data.frame(
+    Gene = c("both_boundary", "p_boundary", "fc_boundary", "neither"),
+    annotation = c("a", "b", "c", "d"),
+    `B-A_logFC` = c(1, 0.5, 1, 0.5),
+    `B-A_pval` = c(0.05, 0.05, 0.06, 0.06),
+    check.names = FALSE
+  )
+
+  plot_volcano_enhanced(
+    boundary_data,
+    feature_id_colname = "Gene",
+    change_colname = "B-A_logFC",
+    signif_colname = "B-A_pval",
+    label_significant_features_only = TRUE,
+    save_plots = FALSE,
+    print_plots = FALSE
+  )
+
+  captured_labels <- getOption("mosuite_test_volcano_label_args")[[1]]$selectLab
+  expect_length(captured_labels, 0)
 })
 
 test_that("plot_volcano_enhanced uses EnhancedVolcano default colors", {

--- a/tests/testthat/test-plot_volcano_enhanced.R
+++ b/tests/testthat/test-plot_volcano_enhanced.R
@@ -116,16 +116,24 @@ test_that("plot_volcano_enhanced colors exact threshold boundaries as non-signif
     print_plots = FALSE
   )
 
-  captured_colors <- getOption("mosuite_test_volcano_boundary_args")[[1]]$colCustom
+  captured_colors <- getOption("mosuite_test_volcano_boundary_args")[[
+    1
+  ]]$colCustom
   expect_equal(
     captured_colors[names(captured_colors) == "Not significant"],
     rep("grey30", 2)
   )
   expect_true(
-    all(captured_colors[names(captured_colors) == "Significant only"] == "royalblue")
+    all(
+      captured_colors[names(captured_colors) == "Significant only"] ==
+        "royalblue"
+    )
   )
   expect_true(
-    all(captured_colors[names(captured_colors) == "Fold change only"] == "forestgreen")
+    all(
+      captured_colors[names(captured_colors) == "Fold change only"] ==
+        "forestgreen"
+    )
   )
 })
 

--- a/tests/testthat/test-plot_volcano_summary.R
+++ b/tests/testthat/test-plot_volcano_summary.R
@@ -48,7 +48,10 @@ test_that("plot_volcano_summary excludes features on exact thresholds", {
   )
 
   expect_false(
-    any(c("both_boundary", "p_boundary", "fc_boundary", "neither") %in% result$Gene)
+    any(
+      c("both_boundary", "p_boundary", "fc_boundary", "neither") %in%
+        result$Gene
+    )
   )
 })
 

--- a/tests/testthat/test-plot_volcano_summary.R
+++ b/tests/testthat/test-plot_volcano_summary.R
@@ -28,6 +28,30 @@ test_that("plot_volcano_summary respects non-Gene feature ID column", {
   expect_false("Gene" %in% colnames(df_volc_sum))
 })
 
+test_that("plot_volcano_summary excludes features on exact thresholds", {
+  boundary_data <- data.frame(
+    Gene = c("both_boundary", "p_boundary", "fc_boundary", "neither"),
+    `B-A_logFC` = c(1, 0.5, 1, 0.5),
+    `B-A_pval` = c(0.05, 0.05, 0.06, 0.06),
+    `B-A_tstat` = c(2, 2, 2, 2),
+    check.names = FALSE
+  )
+
+  result <- plot_volcano_summary(
+    boundary_data,
+    feature_id_colname = "Gene",
+    change_colname = "B-A_logFC",
+    signif_colname = "B-A_pval",
+    add_deg_columns = "none",
+    save_plots = FALSE,
+    print_plots = FALSE
+  )
+
+  expect_false(
+    any(c("both_boundary", "p_boundary", "fc_boundary", "neither") %in% result$Gene)
+  )
+})
+
 test_that("plot_volcano_summary only forwards custom labels when requested", {
   options(mosuite_test_select_labels = list())
   trace(


### PR DESCRIPTION
## Changes

This PR resolves threshold-consistency issues identified from Issue #249 across MOSuite, including Volcano and Differential filtering paths.

The changes:

- Align Enhanced Volcano threshold semantics with strict comparisons:
  - p-value is significant when p < signif_threshold
  - absolute fold change is significant when abs(logFC) > change_threshold
- Keep Enhanced volcano labeling consistent with strict classification at boundary values.
- Replace positional threshold references with resolved column-name access in Enhanced Volcano classification logic.
- Pass explicit per-feature colors to EnhancedVolcano using resolved logFC and significance columns.
- Apply the same strict threshold semantics when Summary constructs significant-feature output.
- Extend threshold consistency to Differential filtering behavior so fold-change and significance comparisons follow the same strict policy package-wide.
- Update user-facing threshold wording/messages where needed to reflect strict comparisons.
- Document threshold behavior in Volcano roxygen documentation.
- Add boundary-value regression tests for features exactly on p-value and fold-change cutoffs.
- Keep Enhanced responsible for per-contrast visualization and Summary responsible for combined multi-contrast composition.

## Issues

Towards #249 (does not fully address the issue)

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [x] Write unit tests for any new features, bug fixes, or other code changes.
- [x] Update the docs if there are any API changes (roxygen2 comments, vignettes, readme, etc.).
- [x] Update `NEWS.md` with a short description of any user-facing changes and reference the PR number. Follow the style described in <https://style.tidyverse.org/news.html>
- [x] Run `devtools::check()` locally and fix all notes, warnings, and errors.
