### PR TITLE
fix: normalize_counts() use normalized counts for correlation heatmap

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -605,7 +605,7 @@ references:
   doi: 10.32614/CRAN.package.broom
 - type: software
   title: cffr
-  abstract: 'cffr: Generate Citation File Format (''CFF'') Metadata for R Packages'
+  abstract: 'cffr: Generate Citation File Format (''CFF'') Metadata'
   notes: Suggests
   url: https://docs.ropensci.org/cffr/
   repository: https://CRAN.R-project.org/package=cffr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 ## MOSuite development version
 
+- `normalize_counts()` now uses normalized counts instead of filtered counts for
+  the correlation heatmap so it matches the PCA and histogram outputs. (#269,
+  @phoman14)
+
 ## MOSuite 0.4.1
 
 - Fix how `plot_volcano_summary()` & `plot_volcano_enhanced` handle detecting column names for features, significance, and fold-change. `plot_volcano_summary()` plot now uses `plot_volcano_enhanced()` for rendering. (#239, @phoman14)

--- a/R/normalize.R
+++ b/R/normalize.R
@@ -157,7 +157,7 @@ normalize_counts <- function(
     }
     if (isTRUE(plot_corr_matrix_heatmap)) {
       corHM_plot <- plot_corr_heatmap(
-        df.filt,
+        df.voom,
         sample_metadata = sample_metadata,
         sample_id_colname = sample_id_colname,
         feature_id_colname = feature_id_colname,


### PR DESCRIPTION
## Changes

Fix `normalize_counts()` so the QC correlation heatmap is generated from the normalized voom counts, matching the normalized PCA and histogram outputs.

## Issues

No linked issue.

## PR Checklist

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [ ] ~Write unit tests for any new features, bug fixes, or other code changes.~
- [x] Update the docs if there are any API changes (roxygen2 comments, vignettes, readme, etc.).
- [x] Update `NEWS.md` with a short description of any user-facing changes and reference the PR number. Follow the style described in <https://style.tidyverse.org/news.html>
- [x] Run `devtools::check()` locally and fix all notes, warnings, and errors.

Validation:
- Confirmed `normalize_counts()` now passes `df.voom` to `plot_corr_heatmap()`.
- No new unit test added per review; the heatmap input now follows the same normalized counts object already used for PCA and histogram.
